### PR TITLE
Set TypedDict module correctly when using class definition syntax (#2)

### DIFF
--- a/tests/testextensions.py
+++ b/tests/testextensions.py
@@ -97,8 +97,8 @@ class TypedDictTests(BaseTestCase):
 
     @skipUnless(PY36, 'Python 3.6 required')
     def test_py36_class_syntax_usage(self):
-        self.assertEqual(LabelPoint2D.__name__, 'LabelPoint2D')
-        self.assertEqual(LabelPoint2D.__module__, __name__)
+        self.assertEqual(LabelPoint2D.__name__, 'LabelPoint2D')  # noqa
+        self.assertEqual(LabelPoint2D.__module__, __name__)  # noqa
         self.assertEqual(LabelPoint2D.__annotations__, {'x': int, 'y': int, 'label': str})  # noqa
         self.assertEqual(LabelPoint2D.__bases__, (dict,))  # noqa
         self.assertEqual(LabelPoint2D.__total__, True)  # noqa

--- a/tests/testextensions.py
+++ b/tests/testextensions.py
@@ -97,6 +97,8 @@ class TypedDictTests(BaseTestCase):
 
     @skipUnless(PY36, 'Python 3.6 required')
     def test_py36_class_syntax_usage(self):
+        self.assertEqual(LabelPoint2D.__name__, 'LabelPoint2D')
+        self.assertEqual(LabelPoint2D.__module__, __name__)
         self.assertEqual(LabelPoint2D.__annotations__, {'x': int, 'y': int, 'label': str})  # noqa
         self.assertEqual(LabelPoint2D.__bases__, (dict,))  # noqa
         self.assertEqual(LabelPoint2D.__total__, True)  # noqa


### PR DESCRIPTION
I shuffled the code so that we only override `__module__` when TypedDict is instantiated (and not when it's subclassed). 

And I tested that `__module__` is correct with both syntaxes.
```
$ cat foo.py
from mypy_extensions import TypedDict


class Person(TypedDict):
    name: str

Host = TypedDict("Host", {"name": "str"})
$ python3
Python 3.6.2+ (heads/master-dirty:404de642c0, Sep 15 2017, 15:52:01)
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import foo
>>> foo.Host
<class 'foo.Host'>
>>> foo.Host.__module__
'foo'
>>> foo.Person
<class 'foo.Person'>
>>> foo.Person.__module__
'foo'
```