### PR TITLE
.travis.yml: The 'sudo' tag is now deprecated in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 cache: pip
 # newer python versions are available only on xenial (while some older only on trusty) Ubuntu distribution
 dist: trusty
-sudo: required
 
 env:
   TOXENV=py


### PR DESCRIPTION
Fixes #6