### PR TITLE
Add an undocumented mypyc_attr decorator

### DIFF
--- a/mypy_extensions.py
+++ b/mypy_extensions.py
@@ -144,6 +144,10 @@ def trait(cls):
     return cls
 
 
+def mypyc_attr(*attrs, **kwattrs):
+    return lambda x: x
+
+
 # TODO: We may want to try to properly apply this to any type
 # variables left over...
 class _FlexibleAliasClsApplied:


### PR DESCRIPTION
This is an (for-now) undocumented annotation to allow specifying
various hints to mypyc. `trait` could have used this instead of
being its own thing.