### PR TITLE
Update URL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     long_description=long_description,
     author='The mypy developers',
     author_email='jukka.lehtosalo@iki.fi',
-    url='http://www.mypy-lang.org/',
+    url='https://github.com/python/mypy_extensions',
     license='MIT License',
     py_modules=['mypy_extensions'],
     classifiers=classifiers,


### PR DESCRIPTION
It's quite hard to find this repository if you don't know about it being split from mypy - so I think it'd be better to link to this repository rather than the mypy website.