### PR TITLE
Drop Python 3.4 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ classifiers = [
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.9.1
 skip_missing_interpreters = true
-envlist = py27, py34, py35, py36, py37
+envlist = py27, py35, py36, py37
 
 [testenv]
 description = run the test driver with {basepython}


### PR DESCRIPTION
PyPI stats indicates that 0.00% of downloads are for Python 3.4: https://www.pypistats.org/packages/mypy-extensions

Other supported Python versions have non-trivial downloads, so let's continue to support them for now.