### PR TITLE
Add 3.10 and 3.11 to classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ classifiers = [
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Topic :: Software Development',
 ]
 


### PR DESCRIPTION
I'm not updating .travis.yml since Travis CI is no longer functioning.