### PR TITLE
Add Python 3.8 to 3.11 to tox envs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.9.1
 skip_missing_interpreters = true
-envlist = py27, py35, py36, py37
+envlist = py27, py35, py36, py37, py38, py39, py310, py311
 
 [testenv]
 description = run the test driver with {basepython}


### PR DESCRIPTION
Now `tox run` runs tests on all supported Python versions. One 3.11 test is still failing -- I'll look at it later.