### PR TITLE
Fix test_typeddict_errors test case on Python 3.11

### DIFF
--- a/tests/testextensions.py
+++ b/tests/testextensions.py
@@ -89,9 +89,9 @@ class TypedDictTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(dict, Emp)  # type: ignore
         with self.assertRaises(TypeError):
-            TypedDict('Hi', x=1)
+            TypedDict('Hi', x=())
         with self.assertRaises(TypeError):
-            TypedDict('Hi', [('x', int), ('y', 1)])
+            TypedDict('Hi', [('x', int), ('y', ())])
         with self.assertRaises(TypeError):
             TypedDict('Hi', [('x', int)], y=int)
 


### PR DESCRIPTION
Integers are now accepted as types in many runtime contexts: https://github.com/python/cpython/issues/90802

Fixes #24.