### PR TITLE
Drop Python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ env:
 
 jobs:
   include:
-  - python: 2.7
-  - python: 3.4
   - python: 3.5.0
   - python: 3.5.1
   - python: 3.5.2

--- a/mypy_extensions.py
+++ b/mypy_extensions.py
@@ -7,8 +7,6 @@ Example usage:
 
 from typing import Any
 
-# NOTE: This module must support Python 2.7 in addition to Python 3.x
-
 import sys
 # _type_check is NOT a part of public typing API, it is used here only to mimic
 # the (convenient) behavior of types provided by typing module.
@@ -98,7 +96,7 @@ TypedDict.__doc__ = \
             label: str
 
     The latter syntax is only supported in Python 3.6+, while two other
-    syntax forms work for Python 2.7 and 3.2+
+    syntax forms work for 3.2+
     """
 
 # Argument constructors for making more-detailed Callables. These all just

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-# NOTE: This package must support Python 2.7 in addition to Python 3.x
-
 from setuptools import setup
 
 version = '0.5.0-dev'
@@ -17,8 +15,6 @@ classifiers = [
     'Environment :: Console',
     'Intended Audience :: Developers',
     'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
@@ -41,7 +37,4 @@ setup(
     license='MIT License',
     py_modules=['mypy_extensions'],
     classifiers=classifiers,
-    install_requires=[
-        'typing >= 3.5.3; python_version < "3.5"',
-    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.9.1
 skip_missing_interpreters = true
-envlist = py27, py35, py36, py37, py38, py39, py310, py311
+envlist = py35, py36, py37, py38, py39, py310, py311
 
 [testenv]
 description = run the test driver with {basepython}


### PR DESCRIPTION
Mypy has dropped Python 2 support some time ago, and maintaining Python 2 support is getting too complicated for little benefit.