### PR TITLE
Require Python 3.5+ in setup.py and setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-universal=1
+universal=0

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ classifiers = [
 
 setup(
     name='mypy_extensions',
+    python_requires='>=3.5',
     version=version,
     description=description,
     long_description=long_description,


### PR DESCRIPTION
Followed these instructions:
https://packaging.python.org/en/latest/guides/dropping-older-python-versions/

I'm not going to make a release with `python_requires>='2.7'` first as suggested
by the docs, since dropping universal wheels should be enough to not have this
version installed on Python 2, and since 3.4 and earlier are basically non-existent
at this point.