### PR TITLE
Add license-files to pyproject.toml so we can upload to pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors     = [
     {name = "The mypy developers", email = "jukka.lehtosalo@iki.fi"}
 ]
 license     = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",


### PR DESCRIPTION
otherwise we get:
```
ERROR    InvalidDistribution: Invalid distribution metadata: unrecognized or malformed field 'license-file'; unrecognized or malformed field 'license-expression'
```