### PR TITLE
Bump version for development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name        = "mypy_extensions"
-version     = "1.1.0-dev"
+version     = "1.2.0-dev"
 description = "Type system extensions for programs checked with the mypy type checker."
 readme      = "README.md"
 authors     = [


### PR DESCRIPTION
Now that we released version 1.1.0, we need to bump the development version on master