### PR TITLE
Flit Core needs license as dict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme      = "README.md"
 authors     = [
     {name = "The mypy developers", email = "jukka.lehtosalo@iki.fi"}
 ]
-license     = "MIT"
+license     = { text = "MIT" }
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",


### PR DESCRIPTION
Flit Core 3.9 needs license as dict instead of str to build package. This is needed for nix to build the package.