### PR TITLE
feat: validate mypyc_attr args

### DIFF
--- a/mypy_extensions.py
+++ b/mypy_extensions.py
@@ -33,6 +33,7 @@ class MypycAttrs(TypedDict):
     native_class: NotRequired[bool]
     allow_interpreted_subclasses: NotRequired[bool]
     serializable: NotRequired[bool]
+    free_list_len: NotRequired[int]
 
 
 def _check_fails(cls, other):

--- a/mypy_extensions.py
+++ b/mypy_extensions.py
@@ -5,7 +5,7 @@ Example usage:
     from mypy_extensions import TypedDict
 """
 
-from typing import Any, Dict, Final, Literal
+from typing import Any, Callable, Dict, Final, Literal, TypeVar
 
 import sys
 # _type_check is NOT a part of public typing API, it is used here only to mimic
@@ -14,6 +14,8 @@ from typing import _type_check  # type: ignore [attr-defined]
 
 from typing_extensions import NotRequired, TypeGuard, Unpack
 
+
+_C = TypeVar("_C", bound=Callable[..., Any])
 
 MYPYC_ATTRS: Final = frozenset([
     "native_class",
@@ -186,7 +188,7 @@ def _validate_mypyc_attr_key(key: str) -> TypeGuard[MypycAttr]:
         )
 
 
-def mypyc_attr(*attrs: MypycAttr, **kwattrs: Unpack[MypycAttrs]):
+def mypyc_attr(*attrs: MypycAttr, **kwattrs: Unpack[MypycAttrs]) -> Callable[[_C], _C]:
     for key in attrs:
         _validate_mypyc_attr_key(key)
     for key, value in kwattrs.items():
@@ -196,8 +198,7 @@ def mypyc_attr(*attrs: MypycAttr, **kwattrs: Unpack[MypycAttrs]):
     return lambda x: x
 
 
-# TODO: We may want to try to properly apply this to any type
-# variables left over...
+# TODO: We may want to try to properly apply this to any type variables left over...
 class _FlexibleAliasClsApplied:
     def __init__(self, val):
         self.val = val

--- a/mypy_extensions.py
+++ b/mypy_extensions.py
@@ -21,12 +21,14 @@ MYPYC_ATTRS: Final = frozenset([
     "native_class",
     "allow_interpreted_subclasses",
     "serializable",
+    "free_list_len",
 ])
 
 MypycAttr = Literal[
     "native_class",
     "allow_interpreted_subclasses",
     "serializable",
+    "free_list_len",
 ]
 
 class MypycAttrs(TypedDict):


### PR DESCRIPTION
This PR implements validation for `mypyc_attr` arguments and more informational type hints for its signature

Sometimes I'll prototype a design in pure-python before I compile it for the first time, this would be helpful for validating the prototype before spending time compiling.