### PR TITLE
feat(docs): docstring for `mypyc_attr`

### DIFF
--- a/mypy_extensions.py
+++ b/mypy_extensions.py
@@ -167,12 +167,12 @@ def mypyc_attr(*attrs, **kwattrs):
         The following 2 snippets are equivalent:
 
         Using positional arguments:
-        
+
             @mypyc_attr("serializable", "allow_interpreted_subclasses")
             class MyClass: ...
-        
+
         Using keyword arguments:
-        
+
             @mypyc_attr(serializable=True, allow_interpreted_subclasses=True)
             class MyClass: ...
     """

--- a/mypy_extensions.py
+++ b/mypy_extensions.py
@@ -168,11 +168,13 @@ def mypyc_attr(*attrs, **kwattrs):
 
         Using positional arguments:
         
-            mypyc_attr("serializable", "allow_interpreted_subclasses")
+            @mypyc_attr("serializable", "allow_interpreted_subclasses")
+            class MyClass: ...
         
         Using keyword arguments:
         
-            mypyc_attr(serializable=True, allow_interpreted_subclasses=True)
+            @mypyc_attr(serializable=True, allow_interpreted_subclasses=True)
+            class MyClass: ...
     """
     # TODO: add some information on the available attrs so it can be viewed directly in user's IDE
     return lambda x: x

--- a/mypy_extensions.py
+++ b/mypy_extensions.py
@@ -162,11 +162,17 @@ def mypyc_attr(*attrs, **kwattrs):
     """
     Define specific attributes for the decorated object when compiled with mypyc.
 
-    This decorator can be used with args or with kwargs. The following 2 snippets are the same:
-    
-    `mypyc_attr("serializable", "allow_interpreted_subclasses")`
-    
-    `mypyc_attr(serializable=True, allow_interpreted_subclasses=True)`
+    Examples:
+        This decorator can be used with args or with kwargs.
+        The following 2 snippets are equivalent:
+
+        Using positional arguments:
+        
+            mypyc_attr("serializable", "allow_interpreted_subclasses")
+        
+        Using keyword arguments:
+        
+            mypyc_attr(serializable=True, allow_interpreted_subclasses=True)
     """
     # TODO: add some information on the available attrs so it can be viewed directly in user's IDE
     return lambda x: x

--- a/mypy_extensions.py
+++ b/mypy_extensions.py
@@ -159,6 +159,16 @@ def trait(cls):
 
 
 def mypyc_attr(*attrs, **kwattrs):
+    """
+    Define specific attributes for the decorated object when compiled with mypyc.
+
+    This decorator can be used with args or with kwargs. The following 2 snippets are the same:
+    
+    `mypyc_attr("serializable", "allow_interpreted_subclasses")`
+    
+    `mypyc_attr(serializable=True, allow_interpreted_subclasses=True)`
+    """
+    # TODO: add some information on the available attrs so it can be viewed directly in user's IDE
     return lambda x: x
 
 


### PR DESCRIPTION
I find in-editor tooltips to be very helpful when learning new tools, so I added a simple docstring for mypyc_attr with info I wish I knew originally.

Longer term I'd like to expand this docstring with info on the various attrs and what they do, but I don't want to start on that unless this is approved.